### PR TITLE
Only check if overdrive bit is set instead of requiring the full ppfeaturemask

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,14 @@ Contributions can be made in terms of:
  Just try to run WattmanGTK. It will tell you if your card does not 
  support overdrive. Even if this is not the case you can set a kernel 
  parameter to force overdrive to be enabled (may not work on all cards).
- For more information on how to set the parameter check the (Arch Wiki)[https://wiki.archlinux.org/index.php/kernel_parameters]
+ For more information on how to set the parameter check the [Arch Wiki](https://wiki.archlinux.org/index.php/kernel_parameters)
  For GRUB based systems (like ubuntu): edit the /etc/default/grub file and edit the line:
 ```
     GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"
 ```
 And change it to:
 ```
-    GRUB_CMDLINE_LINUX_DEFAULT="quiet splash amdgpu.ppfeaturemask=<the 
-suggested value>"
+    GRUB_CMDLINE_LINUX_DEFAULT="quiet splash amdgpu.ppfeaturemask=<the suggested value by WattmanGTK>"
 ```
 Then grub needs to be updated, for ubuntu this is done by running
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a Python3 program which uses a simple GTK gui to view, monitor and in th
  * Python3-matplotlib
  * Python3-gi
  * A Radeon card which uses the AMDGPU kernel driver
- * The kernel parameter amdgpu.ppfeaturemask=0xffffffff must be set.
+ * The overdrive kernel parameter must be set.
 ## Usage
 The tool can be launched from the command line. Clone the repository and open a terminal in this folder. First make the wattman.py file executable by
 ```
@@ -36,15 +36,19 @@ Contributions can be made in terms of:
  * Donations can be made on http://paypal.me/pools/c/89hdUKrx2Z
  * Other contributions are also possible, please let me know
  ## FAQ
- ### How to set the kernel parameter ?
- For more information look here https://wiki.archlinux.org/index.php/kernel_parameters
+ ### How do I know my card has the overdrive bit enabled
+ Just try to run WattmanGTK. It will tell you if your card does not 
+ support overdrive. Even if this is not the case you can set a kernel 
+ parameter to force overdrive to be enabled (may not work on all cards).
+ For more information on how to set the parameter check the (Arch Wiki)[https://wiki.archlinux.org/index.php/kernel_parameters]
  For GRUB based systems (like ubuntu): edit the /etc/default/grub file and edit the line:
 ```
     GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"
 ```
 And change it to:
 ```
-    GRUB_CMDLINE_LINUX_DEFAULT="quiet splash amdgpu.ppfeaturemask=0xffffffff"
+    GRUB_CMDLINE_LINUX_DEFAULT="quiet splash amdgpu.ppfeaturemask=<the 
+suggested value>"
 ```
 Then grub needs to be updated, for ubuntu this is done by running
 ```
@@ -60,9 +64,10 @@ Then reboot the machine, if
 ```
    echo "obase=16; $(cat /sys/module/amdgpu/parameters/ppfeaturemask)" | bc
 ```
-returns ```FFFFFFFF``` the parameter  is set correctly
+returns the parameter currently in use by the system.
  ### Setting the kernel parameter causes artifacts and glitching
- This is not an error with this project, but rather a bug in the kernel driver. See https://github.com/BoukeHaarsma23/WattmanGTK/issues/6
+ It could be that setting the kernelparameter can enable features that 
+ should not be enabled which could be the cause.
  ### The programm does not work for me
  Please open an issue here. Furthermore, refer to this thread on reddit for additional help: https://www.reddit.com/r/linux/comments/9tnijg/a_gtk_wattman_like_gui_for_amd_radeon_users/
  

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Contributions can be made in terms of:
  support overdrive. Even if this is not the case you can set a kernel 
  parameter to force overdrive to be enabled (may not work on all cards).
  For more information on how to set the parameter check the [Arch Wiki](https://wiki.archlinux.org/index.php/kernel_parameters)
+
  For GRUB based systems (like ubuntu): edit the /etc/default/grub file and edit the line:
 ```
     GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"
@@ -68,7 +69,7 @@ returns the parameter currently in use by the system.
  It could be that setting the kernelparameter can enable features that 
  should not be enabled which could be the cause.
  ### The programm does not work for me
- Please open an issue here. Furthermore, refer to this thread on reddit for additional help: https://www.reddit.com/r/linux/comments/9tnijg/a_gtk_wattman_like_gui_for_amd_radeon_users/
+ Please open an issue here. Furthermore, refer to this thread on reddit for additional help: [link](https://www.reddit.com/r/linux/comments/9tnijg/a_gtk_wattman_like_gui_for_amd_radeon_users/)
  
  ### The program can not find a certain senor path and fails
 Please refer to: https://github.com/BoukeHaarsma23/WattmanGTK/issues/1

--- a/wattman.py
+++ b/wattman.py
@@ -40,9 +40,35 @@ if __name__ == "__main__":
     linux = platform.release()
     linux_kernelmain = int(linux.split(".")[0])
     linux_kernelsub = int(linux.split(".")[1])
-    if not (0xffffffff == read_featuremask()):
-        print ("AMDGPU is not enabled with proper featuremask. Is amdgpu.ppfeaturemask=0xffffffff set in the command line options?")
+
+    # https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/amd/include/amd_shared.h#L114
+    featuremask = read_featuremask()
+    PP_SCLK_DPM_MASK = bool(featuremask & 0x1)
+    PP_MCLK_DPM_MASK = bool(featuremask & 0x2)
+    PP_PCIE_DPM_MASK = bool(featuremask & 0x4)
+    PP_SCLK_DEEP_SLEEP_MASK = bool(featuremask & 0x8)
+    PP_POWER_CONTAINMENT_MASK = bool(featuremask & 0x10)
+    PP_UVD_HANDSHAKE_MASK = bool(featuremask & 0x20)
+    PP_SMC_VOLTAGE_CONTROL_MASK = bool(featuremask & 0x40)
+    PP_VBI_TIME_SUPPORT_MASK = bool(featuremask & 0x80)
+    PP_ULV_MASK = bool(featuremask & 0x100)
+    PP_ENABLE_GFX_CG_THRU_SMU = bool(featuremask & 0x200)
+    PP_CLOCK_STRETCH_MASK = bool(featuremask & 0x400)
+    PP_OD_FUZZY_FAN_CONTROL_MASK = bool(featuremask & 0x800)
+    PP_SOCCLK_DPM_MASK = bool(featuremask & 0x1000)
+    PP_DCEFCLK_DPM_MASK = bool(featuremask & 0x2000)
+    PP_OVERDRIVE_MASK = bool(featuremask & 0x4000)
+    PP_GFXOFF_MASK = bool(featuremask & 0x8000)
+    PP_ACG_MASK = bool(featuremask & 0x10000)
+    PP_STUTTER_MODE = bool(featuremask & 0x20000)
+    PP_AVFS_MASK = bool(featuremask & 0x40000)
+
+    if not PP_OVERDRIVE_MASK:
+        print ("The overdrive functionality seems not enabled on this system.")
+        print ("This means WattmanGTK can not be used.")
+        print ("You could force it by flipping the overdrive bit. For this system it would mean to set amdgpu.ppfeaturemask=" + hex(featuremask + int("0x4000",16)))
         exit()
+        
     if linux_kernelmain < 4 or (linux_kernelmain > 4 and linux_kernelsub < 17):
         # kernel 4.8 has percentage od source: https://www.phoronix.com/scan.php?page=news_item&px=AMDGPU-OverDrive-Support
         # kernel 4.17 has all wattman functionality source: https://www.phoronix.com/scan.php?page=news_item&px=AMDGPU-Linux-4.17-Round-1


### PR DESCRIPTION
Drop the `amdgpu.ppfeaturemask=0xFFFFFFFF` requirement and only check if the overdrive bit is set. This could solve #6 since only the bit required is set. Also possibly can weed out unsupported setups. (Maybe #13 , #14, #15 ?)