### PR TITLE
Added desktop file to wattmangtk

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[install]
+single-version-externally-managed=1
+record=install.txt

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ setup(
     package_dir = {"WattmanGTK":  "WattmanGTK"},
     package_data = {"WattmanGTK": ["data/wattman.ui"]},
     url = "https://github.com/BoukeHaarsma23/WattmanGTK",
+    data_files = [
+        ('share/applications', ['wattmanGTK.desktop']),
+    ],
     project_urls = {
         "Source": "https://github.com/BoukeHaarsma23/WattmanGTK",
         "Tracker": "https://github.com/BoukeHaarsma23/WattmanGTK/issues",

--- a/wattmanGTK.desktop
+++ b/wattmanGTK.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=WattmanGTK
+Exec=wattmanGTK
+Icon=
+Type=Application
+Categories=GTK;Utility;


### PR DESCRIPTION
Added a .desktop file to wattmangtk to allow execute from display manager
setup.cfg is needed for console_script workaround(https://stackoverflow.com/questions/501597/how-to-distribute-desktop-files-and-icons-for-a-python-package-in-gnome-with)