### PR TITLE
Fix for issue in cases where divide by zero happens when no fan is detected

### DIFF
--- a/WattmanGTK/GPU.py
+++ b/WattmanGTK/GPU.py
@@ -245,7 +245,7 @@ class GPU:
                 raise KeyError
             self.fan_speed = self.sensors['fan']['1']['input']['value']
             self.fan_speed_rpm_utilisation = self.fan_speed / self.sensors['fan']['1']['max']['value']
-        except KeyError:
+        except (KeyError, ZeroDivisionError):
             self.fan_speed_rpm_utilisation = None
             self.fan_speed = 'N/A'
 

--- a/WattmanGTK/plot.py
+++ b/WattmanGTK/plot.py
@@ -122,6 +122,8 @@ class Plot:
                 subsystem = key
                 stop_recursion = False
             if "path" in value:
+                if subsystem == "":
+                    continue
                 if any(path_sensor_to_plot in value["path"] for path_sensor_to_plot in sensors_to_plot):
                     signallabel = value["path"][1:].split("_")[0]
                     signalmax = 0


### PR DESCRIPTION
Fix for issue in cases where divide by zero happens when no fan is detected.

Fix for issue where no subsystem is set in add_available_signal in plot.py. Resolves issue #68 and #66 