### PR TITLE
Fix file not found error

### DIFF
--- a/WattmanGTK/wattman.py
+++ b/WattmanGTK/wattman.py
@@ -147,16 +147,17 @@ def main():
 
     hwmondir = '/sys/class/hwmon/'
     for i,folder in enumerate(os.listdir(hwmondir)):
-        if open(hwmondir + folder + '/name').readline().rstrip() == 'amdgpu':
-            print(f"amdgpu card found in {hwmondir}{folder} hwmon folder")
-            print("Checking which device this hwmon path belongs to")
-            for card in GPUs:
-                if str(Path(f"{hwmondir}{folder}/device").resolve()) == card.cardpath:
-                    print(f"{hwmondir}{folder} belongs to {card.cardpath} ({card.fancyname})")
-                    card.hwmonpath = hwmondir + folder
-                    card.sensors = card.init_sensors()
-                    card.get_states()
-                    break
+        if os.system("[ -e " + hwmondir + folder + '/name' + " ]") == 0:
+            if open(hwmondir + folder + '/name').readline().rstrip() == 'amdgpu':
+                print(f"amdgpu card found in {hwmondir}{folder} hwmon folder")
+                print("Checking which device this hwmon path belongs to")
+                for card in GPUs:
+                    if str(Path(f"{hwmondir}{folder}/device").resolve()) == card.cardpath:
+                        print(f"{hwmondir}{folder} belongs to {card.cardpath} ({card.fancyname})")
+                        card.hwmonpath = hwmondir + folder
+                        card.sensors = card.init_sensors()
+                        card.get_states()
+                        break
 
     # Initialise and present GUI
     builder = Gtk.Builder()


### PR DESCRIPTION
This change adds a check for the existence of the hwmondir name file. This prevents the following error in my system: 
Traceback (most recent call last):
  File "run.py", line 23, in <module>
    wattman.main()
  File "/home/$USER/WattmanGTK/WattmanGTK/wattman.py", line 150, in main
    if open(hwmondir + folder + '/name').readline().rstrip() == 'amdgpu':
FileNotFoundError: [Errno 2] No such file or directory: '/sys/class/hwmon/hwmon3/name'

This error prevented the program from running.

It looks like hwmon3 is 'applesmc' so this could be a mac specific issue.